### PR TITLE
Remove duplicate judgment on dropoff_ingestor property

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -298,16 +298,6 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       return;
     }
 
-    if (delivery.dropoff_place_name.empty())
-    {
-      RCLCPP_ERROR(
-        node->get_logger(),
-        "Required param [delivery.dropoff_place_name] missing in TaskProfile."
-        "Rejecting BidNotice with task_id:[%s]" , id.c_str());
-
-      return;
-    }
-
     if (delivery.dropoff_ingestor.empty())
     {
       RCLCPP_ERROR(


### PR DESCRIPTION
if (delivery.dropoff_ingestor.empty())
{
  RCLCPP_ERROR(
  node->get_logger(),
  "Required param [delivery.dropoff_ingestor] missing in TaskProfile."
  "Rejecting BidNotice with task_id:[%s]" , id.c_str());
  return;
 }

As in the above code, there are two same judgments in the code, and one needs to be removed.